### PR TITLE
package.jsonの依存パッケージをpeerDependenciesに移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,21 @@
   },
   "homepage": "https://github.com/hiroxto/eslint-config#readme",
   "prettier": "@hiroxto/prettier-config",
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.31.1",
+    "@typescript-eslint/parser": "^4.31.1",
+    "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jest": "^24.4.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-standard": "^5.0.0",
+    "eslint-plugin-vue": "^7.17.0",
+    "prettier": "^2.4.0",
+    "typescript": "^4.4.3"
+  },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/hiroxto/eslint-config#readme",
   "prettier": "@hiroxto/prettier-config",
-  "dependencies": {
+  "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
package.jsonの依存パッケージをpeerDependenciesに移動。

peerDependenciesに書く事で自動的に必要な依存パッケージをインストールするようにする